### PR TITLE
update What's Included Section in the Releases page

### DIFF
--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -23,15 +23,15 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 |---------------------------------|-------------------------------|------------------------------------|------------------------|
 | prometheusreceiver              | attributesprocessor           | `awsxrayexporter`                  | healthcheckextension   |
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
-| `awsecscontainermetricsreceiver`| queuedprocessor               | `awsprometheusremotewriteexporter` | zpagesextension        |
-| `awsxrayreceiver`               | batchprocessor                | loggingexporter                    |                        |
-| `statsdreceiver`                | memorylimiter                 | otlpexporter                       |                        |
-| zipkinreceiver                  | tailsamplingprocessor         | fileexporter                       |                        |
-| jaegerreceiver                  | probabilisticsamplerprocessor | otlphttpexporter                   |                        |
-|                                 | spanprocessor                 | prometheusexporter                 |                        |
-|                                 | filterprocessor               | datadogexporter                    |                        |
-|                                 | metricstransformprocessor     | dynatraceexporter                  |                        |
-|                                 | resourcedetectionprocessor    | newrelicexporter                   |                        |
+| `awsecscontainermetricsreceiver`| batchprocessor                | `awsprometheusremotewriteexporter` | zpagesextension        |
+| `awsxrayreceiver`               | memorylimiter                 | loggingexporter                    | `ecsobserver`          |
+| `statsdreceiver`                | tailsamplingprocessor         | otlpexporter                       |                        |
+| zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       |                        |
+| jaegerreceiver                  | spanprocessor                 | otlphttpexporter                   |                        |
+| `awscontainerinsightreceiver`   | filterprocessor               | prometheusexporter                 |                        |
+|                                 | metricstransformprocessor     | datadogexporter                    |                        |
+|                                 | resourcedetectionprocessor    | dynatraceexporter                  |                        |
+|                                 |                               | newrelicexporter                   |                        |
 |                                 |                               | sapmexporter                       |                        |
 |                                 |                               | signalfxexporter                   |                        |
 |                                 |                               | logzioexporter                     |                        |


### PR DESCRIPTION
This PR updates - What's Included in the AWS Distro for OpenTelemetry Collector - section in the Releases documentation with AWS OTel Collector components in upcoming release. 

Issue # 163 