### PR TITLE
Add Operator release to the Releases page

### DIFF
--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -14,7 +14,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 | AWS Distro for OpenTelemetry Collector Version                 | <Link to="/download">Download</Link> |
 | AWS X-Ray Playground for OpenTelemetry Version                 | <Link to="/download">Download</Link> |
 | AWS Distro for OpenTelemetry Integeration Test Framework       | <Link to="https://github.com/aws-observability/aws-otel-test-framework/releases">Release</Link> |
-| AWS Distro for OpenTelemetry Operator                          | <Link to="https://gallery.ecr.aws/aws-observability/aws-otel-operator">Download</Link> |
+| AWS Distro for OpenTelemetry Operator                          | <Link to="https://gallery.ecr.aws/aws-observability/adot-operator">Download</Link> |
 
 <SectionSeparator />
 

--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -14,6 +14,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 | AWS Distro for OpenTelemetry Collector Version                 | <Link to="/download">Download</Link> |
 | AWS X-Ray Playground for OpenTelemetry Version                 | <Link to="/download">Download</Link> |
 | AWS Distro for OpenTelemetry Integeration Test Framework       | <Link to="https://github.com/aws-observability/aws-otel-test-framework/releases">Release</Link> |
+| AWS Distro for OpenTelemetry Operator                          | <Link to="https://gallery.ecr.aws/aws-observability/aws-otel-operator">Download</Link> |
 
 <SectionSeparator />
 


### PR DESCRIPTION
This PR updates the Releases documentation with the addition of a link to download the Operator release in Public ECR.

Issue # 162