### PR TITLE
update Downloads page to include ADOT Collector and Operator public E…

### DIFF
--- a/src/content/Downloads/downloads.yaml
+++ b/src/content/Downloads/downloads.yaml
@@ -1,3 +1,17 @@
+- version: 'Amazon ECR:AWS Distro for OpenTelemetry Collector'
+  releaseDate: 'Aug-31-2021'
+  license: 'Apache-2.0'
+  releaseNotesLink: 'https://github.com/aws-observability/aws-otel-collector/releases'
+  documentationLink: 'https://github.com/aws-observability/aws-otel-collector/blob/main/README.md'
+  downloadLink: 'https://gallery.ecr.aws/aws-observability/aws-otel-collector'
+
+- version: 'Amazon ECR:AWS Distro for OpenTelemetry Operator'
+  releaseDate: 'Aug-31-2021'
+  license: 'Apache-2.0'
+  releaseNotesLink: 'https://github.com/aws-observability/aws-otel-collector/releases'
+  documentationLink: 'https://aws-otel.github.io/docs/getting-started/operator'
+  downloadLink: 'https://gallery.ecr.aws/aws-observability/aws-otel-operator'
+
 - version: 'AWS Distro for OpenTelemetry Collector Version 0.12.0'
   releaseDate: 'Aug-31-2021'
   license: 'Apache-2.0'

--- a/src/content/Downloads/downloads.yaml
+++ b/src/content/Downloads/downloads.yaml
@@ -10,7 +10,7 @@
   license: 'Apache-2.0'
   releaseNotesLink: 'https://github.com/aws-observability/aws-otel-collector/releases'
   documentationLink: 'https://aws-otel.github.io/docs/getting-started/operator'
-  downloadLink: 'https://gallery.ecr.aws/aws-observability/aws-otel-operator'
+  downloadLink: 'https://gallery.ecr.aws/aws-observability/adot-operator'
 
 - version: 'AWS Distro for OpenTelemetry Collector Version 0.12.0'
   releaseDate: 'Aug-31-2021'


### PR DESCRIPTION
This PR updates the Downloads page to include ADOT public ECR links for AWS Distro for OpenTelemetry Collector and AWS Distro for OpenTelemetry Operator to provide easy access to downloading Docker images. 

Issue # 159