### PR TITLE
Update ADOT Blog Posts

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,48 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry 0.14 is now available with updated Lambda layers"
+    author: "Alolita Sharma and Raman Aulakh"
+    date: "12-Nov-2021"
+    body:
+      "AWS Distro for OpenTelemetry 0.14 is now available. You can download the latest AWS Distro for OpenTelemetry Collector image
+      from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery."
+    link: "https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-0-14-is-now-available-with-updated-lambda-layers/"
+
+  - title: "Auto-instrumenting a Python application with an AWS Distro for OpenTelemetry Lambda layer"
+    author: "Nathaniel Ruiz Nowell"
+    date: "11-Nov-2021"
+    body:
+      "Customers want better insight into understanding the behavior of their systems, but not all customers can
+      afford to make significant code changes in their existing pipelines to add more observability.
+      In this walkthrough, we explain how to get telemetry data from AWS Lambda Python functions ..."
+    link: "https://aws.amazon.com/blogs/opensource/auto-instrumenting-a-python-application-with-an-aws-distro-for-opentelemetry-lambda-layer/"
+
+  - title: "AWS Distro for OpenTelemetry is now GA for tracing"
+    author: "Alolita Sharma and Nizar Tyrewalla"
+    date: "29-Sep-2021"
+    body:
+      "AWS Distro for OpenTelemetry (ADOT) is now generally available with production-ready tracing support.
+      You can download the latest ADOT Collector image from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery."
+    link: "https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/"
+
+  - title: "Simplifying OpenTelemetry Collector and Go library releases with the Go MultiMod tool"
+    author: "Alolita Sharma"
+    date: "24-Sep-2021"
+    body:
+      "Managing versions and releases of multiple Go Modules can be a struggle to perform manually for maintainers of large repositories, especially
+      due to the lack of official Golang support for this task. In this post, AWS Observability intern software engineer Eddy Lin discusses his experience
+      building the Go MultiMod tool, an open source solution that automates ..."
+    link: "https://aws.amazon.com/blogs/opensource/simplifying-opentelemetry-collector-and-go-library-releases-with-the-go-multimod-tool/"
+
+  - title: "AWS Lambda metrics support for Amazon Managed Service for Prometheus now available in AWS Distro for OpenTelemetry"
+    author: "Alolita Sharma"
+    date: "15-Sep-2021"
+    body:
+      "In this blog post, intern engineers Karen Xu and Kelvin Lo describe how they added metric support to the OpenTelemetry and AWS Distro for OpenTelemetry Lambda layers,
+      and built and tested the metric pipeline to generate, collect, and export application metrics from AWS Lambda to Amazon Managed Service for Prometheus (AMP)."
+    link: "https://aws.amazon.com/blogs/opensource/aws-lambda-metrics-support-for-amazon-managed-service-for-prometheus-now-available-in-aws-distro-for-opentelemetry/"
+
   - title: "AWS Distro for OpenTelemetry 0.12 adds metrics support for AWS Lambda, Amazon ECS on EC2 metrics, and Amazon EKS metrics in Amazon Managed Prometheus (Preview)"
     author: "Alolita Sharma and Nizar Tyrewalla"
     date: "31-Aug-2021"


### PR DESCRIPTION
This PR is to update the ADOT blog to reflect all published posts for ADOT on the AWS Open Source blog - https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/

Issue # 203 